### PR TITLE
fix(L1-003, L1-004): train.py GradScaler CPU crash & dataset.py unnormalized class weights

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -95,8 +95,13 @@ class ChestXrayDataset(Dataset):
         return img, self.labels[idx]
 
     def get_class_weights(self):
-        """Return inverse-frequency weights per class for weighted sampling."""
+        """Return normalized inverse-frequency weights per class.
+
+        FIX L1-004: Raw neg/(pos+eps) ratios can be extremely large for rare
+        classes (e.g. Hernia), destabilizing BCEWithLogitsLoss and
+        WeightedRandomSampler. Normalize to mean=1 for stable training.
+        """
         pos = self.labels.sum(axis=0)
         neg = len(self.labels) - pos
         weights = neg / (pos + 1e-6)
-        return weights
+        return weights / weights.mean()  # normalize to mean=1

--- a/src/train.py
+++ b/src/train.py
@@ -87,7 +87,7 @@ def train_epoch(model, loader, optimizer, criterion, scaler, device, use_amp, gr
         imgs, labels = imgs.to(device), labels.to(device)
         optimizer.zero_grad()
 
-        with autocast(device_type='cuda', enabled=use_amp):
+        with autocast(device_type=device, enabled=use_amp):
             logits = model(imgs)
             loss   = criterion(logits, labels)
 
@@ -114,7 +114,7 @@ def evaluate(model, loader, criterion, device, use_amp, class_names):
 
     for imgs, labels in tqdm(loader, desc='  Eval ', leave=False):
         imgs, labels = imgs.to(device), labels.to(device)
-        with autocast(device_type='cuda', enabled=use_amp):
+        with autocast(device_type=device, enabled=use_amp):
             logits = model(imgs)
             loss   = criterion(logits, labels)
         total_loss += loss.item()
@@ -189,7 +189,11 @@ def main():
     else:
         scheduler = None
 
-    scaler    = GradScaler('cuda', enabled=cfg['training']['amp'])
+    # FIX L1-003: GradScaler must use dynamic device, not hardcoded 'cuda'.
+    # Also disable AMP if not on CUDA to prevent ValueError on CPU machines.
+    use_amp = cfg['training']['amp'] and device == 'cuda'
+    scaler  = GradScaler(device, enabled=use_amp)
+
     save_dir  = Path(cfg['logging']['save_dir'])
     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -207,11 +211,11 @@ def main():
 
         train_loss = train_epoch(
             model, loaders['train'], optimizer, criterion,
-            scaler, device, cfg['training']['amp'], cfg['training']['grad_clip']
+            scaler, device, use_amp, cfg['training']['grad_clip']
         )
         val_loss, val_aucs = evaluate(
             model, loaders['val'], criterion, device,
-            cfg['training']['amp'], class_names
+            use_amp, class_names
         )
 
         if scheduler:
@@ -245,7 +249,7 @@ def main():
     print('\nRunning test set evaluation...')
     test_loss, test_aucs = evaluate(
         model, loaders['test'], criterion, device,
-        cfg['training']['amp'], class_names
+        use_amp, class_names
     )
     print(f'\nTest Loss : {test_loss:.4f}')
     print(f'Test AUC  : {test_aucs["mean"]:.4f}')


### PR DESCRIPTION
## Summary
This PR fixes two L1-level atomic bugs in `src/train.py` and `src/dataset.py`.

---

### 🐛 L1-003 — GradScaler hardcoded to `'cuda'` crashes on CPU (closes #3)
**File:** `src/train.py`

**Before:**
```python
scaler = GradScaler('cuda', enabled=cfg['training']['amp'])  # ❌ crashes on CPU
```
**After:**
```python
use_amp = cfg['training']['amp'] and device == 'cuda'
scaler  = GradScaler(device, enabled=use_amp)  # ✅ device-agnostic
```
Also propagated `use_amp` as a local variable so it's consistent across `train_epoch()` and `evaluate()` calls, removing redundant `cfg['training']['amp']` lookups.

Also updated `autocast(device_type='cuda', ...)` → `autocast(device_type=device, ...)` in both `train_epoch()` and `evaluate()` for full CPU compatibility.

---

### 🐛 L1-004 — `get_class_weights()` returns unnormalized huge ratios (closes #4)
**File:** `src/dataset.py`

**Before:**
```python
weights = neg / (pos + 1e-6)  # ❌ can be ~80,000 for rare classes like Hernia
return weights
```
**After:**
```python
weights = neg / (pos + 1e-6)
return weights / weights.mean()  # ✅ normalized to mean=1, stable for BCEWithLogitsLoss
```

---

**Hierarchy level:** L1 (atomic) → closes remaining 2 of 5 open bugs
**After both PRs merged:** All L1s done → ready to address L100 pipeline-level refactors